### PR TITLE
#337 - Floor save()가 올바르게 작동하도록 수정

### DIFF
--- a/HanzariProject/backend/src/main/java/com/hancom/hanzari/controllers/FloorController.java
+++ b/HanzariProject/backend/src/main/java/com/hancom/hanzari/controllers/FloorController.java
@@ -76,28 +76,11 @@ public class FloorController {
 		if (building == null) {
 			throw new ResourceNotFoundException("Building", "building_id", buildingId);
 		}
-		/*Floor newFloor = Floor.builder().floorId(floorDto.getFloor_id()).floorName(floorDto.getFloor_name())
-				.building(building).floorOrder(floorDto.getFloor_order()).build();*/
-		
-		
-		
-		Floor newFloor = new Floor();
-		newFloor.setFloorId(floorDto.getFloor_id());
-		newFloor.setFloorName(floorDto.getFloor_name());
-		newFloor.setFloorOrder(floorDto.getFloor_order());
-		newFloor.setBuilding(building);
-		//newFloor.setSeats(new ArrayList<Seat>());
-		
-		if(newFloor.getSeats() == null) {
-			System.out.println("#####\n#####\nseats null#####\n#####\n");
-		}
-		else {
-			System.out.println("#####\n#####\nseats not null#####\n#####\n");
-		}
-		
-		floorService.save(newFloor);
-		
-		return new ResponseEntity<Floor>(newFloor, HttpStatus.OK);
+
+		Floor newFloor = Floor.builder().floorId(floorDto.getFloor_id()).floorName(floorDto.getFloor_name())
+				.building(building).floorOrder(floorDto.getFloor_order()).build();
+
+		return new ResponseEntity<Floor>(floorService.save(newFloor), HttpStatus.OK);
 	}
 
 	@DeleteMapping(value = "/{floor_id}", produces = { MediaType.APPLICATION_JSON_VALUE })

--- a/HanzariProject/backend/src/main/java/com/hancom/hanzari/model/Floor.java
+++ b/HanzariProject/backend/src/main/java/com/hancom/hanzari/model/Floor.java
@@ -1,6 +1,5 @@
 package com.hancom.hanzari.model;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.persistence.CascadeType;
@@ -32,7 +31,7 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 @Table(name = "floors")
-//@Builder
+@Builder
 public class Floor {
 
 	@Id
@@ -56,11 +55,10 @@ public class Floor {
 	@Column(name = "floor_image_url", nullable = true)
 	private int floorImageUrl;
 
-	//@OneToMany(mappedBy = "floor", fetch = FetchType.LAZY, cascade = { CascadeType.PERSIST, CascadeType.MERGE }, orphanRemoval = true)
-	@OneToMany(mappedBy = "floor", cascade = CascadeType.ALL, orphanRemoval = true)
+	@OneToMany(mappedBy = "floor", cascade = CascadeType.ALL, orphanRemoval = false)
 	@LazyCollection(LazyCollectionOption.FALSE)
 	@JsonManagedReference
-	private List<Seat> seats = new ArrayList<Seat>();
+	private List<Seat> seats;
 
 	@PreRemove
 	public void preRemove() {
@@ -72,42 +70,10 @@ public class Floor {
 		}
 	}
 
-//	@PrePersist
-//	private void prePersist() {
-//		System.out.println("#####\n#####\nprePersist#####\n#####\n");
-//	}
-
-//	@PreUpdate
-//	public void preUpdate() {
-//		System.out.println("#####\n#####\npreUpdate#####\n#####\n");
-//		if (building != null) {
-//			setBuilding(null);
-//		}
-//		if (seats != null) {
-//			seats.forEach(e -> e.setFloor(null));
-//			this.seats.clear();
-//		}
-//	}
-
 	public void setSeats(List<Seat> seats) {
-		System.out.println("#####\n#####\nFloor.setSeats() called\n #####\n#####\n");
-//		if(seats == null) {
-//	        this.seats.clear();
-//	    }
-//		if (this.seats == null) {
-//			this.seats = seats;
-//		} else {
-//			this.seats.retainAll(seats);
-//			this.seats.addAll(seats);
-//		}
-
-		if (this.seats == null) {
-			this.seats = seats;
-		} else if (this.seats != seats) {
-			this.seats.retainAll(seats);
-			if (seats != null) {
-				this.seats.addAll(seats);
-			}
+		this.seats.clear();
+		if (seats != null) {
+			this.seats.addAll(seats);
 		}
 	}
 

--- a/HanzariProject/backend/src/main/java/com/hancom/hanzari/model/Seat.java
+++ b/HanzariProject/backend/src/main/java/com/hancom/hanzari/model/Seat.java
@@ -79,9 +79,8 @@ public class Seat {
 
 	public SeatDto toDto() {
 		String employeeId = (employee == null) ? null : String.valueOf(employee.getEmployeeId());
-		return SeatDto.builder().seat_id(seatId).floor(floor.getFloorId()).x(x).y(y).is_group(isGroup)
-				.group_id(groupId).building_id(floor.getBuilding().getBuildingId()).employee_id(employeeId)
-				.width(figure.getWidth()).height(figure.getHeight()).degree(figure.getDegree())
-				.shape_id(figure.getShape().getShapeId()).build();
+		return SeatDto.builder().seat_id(seatId).floor(floor.getFloorId()).x(x).y(y).is_group(isGroup).group_id(groupId)
+				.building_id(floor.getBuilding().getBuildingId()).employee_id(employeeId).width(figure.getWidth())
+				.height(figure.getHeight()).degree(figure.getDegree()).shape_id(figure.getShape().getShapeId()).build();
 	}
 }

--- a/HanzariProject/backend/src/main/java/com/hancom/hanzari/service/FloorServiceImpl.java
+++ b/HanzariProject/backend/src/main/java/com/hancom/hanzari/service/FloorServiceImpl.java
@@ -66,7 +66,6 @@ public class FloorServiceImpl implements FloorService {
 
 	@Override
 	public Floor save(Floor floor) {
-		floorRepository.save(floor);
-		return floor;
+		return floorRepository.save(floor);
 	}
 }


### PR DESCRIPTION
* 기존에 처음 등록하는 과정의 save()는 올바르게 작동했으나 floor의 내용이 변경(update)되는 경우 오류발생하던 걸 수정.
 -> Floor 앤티티에서 가지고있는 List<Seat> seats 멤버의 @OneToMany 어노테이션 옵션값 중 orphanRemoval = false 로 줌으로서 수정된 정보로 생성되는 비교를위한 Floor 객체와의 비교 중 자식객체(seats)가 고아객체가되어 사라지지 않게 하므로써 merge된 이후에 새로 갱신된 부모객체(floor)에 다시 매핑되게 수정하였음.