### PR TITLE
#465 Building에 해당하는 Floors 삭제하기 기능

### DIFF
--- a/HanzariProject/backend/src/main/java/com/hancom/hanzari/controllers/FloorController.java
+++ b/HanzariProject/backend/src/main/java/com/hancom/hanzari/controllers/FloorController.java
@@ -64,12 +64,6 @@ public class FloorController {
 	@PostMapping
 	public ResponseEntity<Floor> save(@PathVariable("building_id") String buildingId, @RequestBody FloorDto floorDto)
 			throws Exception {
-		/*
-		 * for (Field field : floorDto.getClass().getDeclaredFields()) {
-		 * field.setAccessible(true); Object value = field.get(floorDto);
-		 * System.out.println(field.getName() + " : " + value + " // type : " +
-		 * value.getClass()); }
-		 */
 
 		Building building = buildingService.findById(buildingId);
 		if (building == null) {

--- a/HanzariProject/backend/src/main/java/com/hancom/hanzari/controllers/TestController.java
+++ b/HanzariProject/backend/src/main/java/com/hancom/hanzari/controllers/TestController.java
@@ -9,15 +9,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.hancom.hanzari.dto.BuildingDto;
 import com.hancom.hanzari.dto.FloorDto;
 import com.hancom.hanzari.dto.SeatDto;
+import com.hancom.hanzari.exception.ResourceNotFoundException;
 import com.hancom.hanzari.model.Building;
 import com.hancom.hanzari.model.Employee;
 import com.hancom.hanzari.model.EmployeeAdditionalInfo;
@@ -35,7 +39,7 @@ import com.hancom.hanzari.service.ShapeService;
 */
 @CrossOrigin(origins = "*", maxAge = 3600)
 @RestController
-@RequestMapping("test-api/")
+@RequestMapping("test-api")
 public class TestController {
 
 	@Autowired
@@ -48,9 +52,8 @@ public class TestController {
 	private EmployeeService employeeService;
 	@Autowired
 	private ShapeService shapeService;
-	
+
 	private final Logger LOGGER = LoggerFactory.getLogger("EngineLogger");
-	
 
 	@Transactional
 	@GetMapping("/inserttestdata")
@@ -124,10 +127,10 @@ public class TestController {
 		buildings.forEach(e -> buildingService.save(e));
 		employee.forEach(e -> employeeService.save(e));
 	}
-	
+
 	@Transactional
 	@RequestMapping("/get-all-buildings")
-	public ResponseEntity<List<BuildingDto>>  getAllBuildings() throws Exception {
+	public ResponseEntity<List<BuildingDto>> getAllBuildings() throws Exception {
 
 		LOGGER.info("TestController.getAllSeats called.");
 		List<Building> buildings = buildingService.findAll();
@@ -135,10 +138,10 @@ public class TestController {
 		buildings.forEach(e -> result.add(e.toDto()));
 		return new ResponseEntity<List<BuildingDto>>(result, HttpStatus.OK);
 	}
-	
+
 	@Transactional
 	@RequestMapping("/get-all-floors")
-	public ResponseEntity<List<FloorDto>>  getAllFloors() throws Exception {
+	public ResponseEntity<List<FloorDto>> getAllFloors() throws Exception {
 
 		LOGGER.info("TestController.getAllSeats called.");
 		List<Floor> floors = floorService.findAll();
@@ -146,10 +149,10 @@ public class TestController {
 		floors.forEach(e -> result.add(e.toDto()));
 		return new ResponseEntity<List<FloorDto>>(result, HttpStatus.OK);
 	}
-	
+
 	@Transactional
 	@RequestMapping("/get-all-seats")
-	public ResponseEntity<List<SeatDto>>  getAllSeats() throws Exception {
+	public ResponseEntity<List<SeatDto>> getAllSeats() throws Exception {
 
 		LOGGER.info("TestController.getAllSeats called.");
 		List<Seat> seats = seatService.findAll();
@@ -157,7 +160,20 @@ public class TestController {
 		seats.forEach(e -> result.add(e.toDto()));
 		return new ResponseEntity<List<SeatDto>>(result, HttpStatus.OK);
 	}
-	
-	
-	
+
+	// 특정 빌딩에 있는 모든 층 삭제
+	@Transactional
+	@DeleteMapping(value = "/buildings/{building_id}/floors", produces = { MediaType.APPLICATION_JSON_VALUE })
+	public ResponseEntity<Void> deleteAllFloorsFromBuilding(@PathVariable("building_id") String buildingId)
+			throws Exception {
+
+		List<Floor> floors = buildingService.findById(buildingId).getFloors();
+		if (floors == null) {
+			throw new ResourceNotFoundException("Floor", "floors", floors);
+		}
+		floors.forEach(e->{System.out.println( "확인 #########" + e.getFloorId() + "\n");});
+		floorService.deleteAllInBatch(floors);
+		return new ResponseEntity<Void>(HttpStatus.NO_CONTENT);
+	}
+
 }

--- a/HanzariProject/backend/src/main/java/com/hancom/hanzari/controllers/TestController.java
+++ b/HanzariProject/backend/src/main/java/com/hancom/hanzari/controllers/TestController.java
@@ -3,56 +3,58 @@ package com.hancom.hanzari.controllers;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.hibernate.Session;
-import org.hibernate.SessionFactory;
-import org.hibernate.Transaction;
-import org.hibernate.cfg.Configuration;
+import javax.transaction.Transactional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Controller;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
 
+import com.hancom.hanzari.dto.BuildingDto;
+import com.hancom.hanzari.dto.FloorDto;
+import com.hancom.hanzari.dto.SeatDto;
 import com.hancom.hanzari.model.Building;
 import com.hancom.hanzari.model.Employee;
 import com.hancom.hanzari.model.EmployeeAdditionalInfo;
+import com.hancom.hanzari.model.Floor;
+import com.hancom.hanzari.model.Seat;
 import com.hancom.hanzari.model.Shape;
+import com.hancom.hanzari.service.BuildingService;
+import com.hancom.hanzari.service.EmployeeService;
+import com.hancom.hanzari.service.FloorService;
+import com.hancom.hanzari.service.SeatService;
+import com.hancom.hanzari.service.ShapeService;
 
 /*
  * TEST에 필요한 메소드들을 모아놓은 Controller
 */
-@Controller
+@CrossOrigin(origins = "*", maxAge = 3600)
+@RestController
+@RequestMapping("test-api/")
 public class TestController {
 
 	@Autowired
-	private static SessionFactory sessionFactory;
+	private SeatService seatService;
+	@Autowired
+	private FloorService floorService;
+	@Autowired
+	private BuildingService buildingService;
+	@Autowired
+	private EmployeeService employeeService;
+	@Autowired
+	private ShapeService shapeService;
+	
+	private final Logger LOGGER = LoggerFactory.getLogger("EngineLogger");
+	
 
-	// view first vue.js->vue.js logo
-	@RequestMapping("/")
-	public String Index() {
-		return "indexing";
-	}
-
-	// view HanzariPrototype->한컴 화면
-	@RequestMapping("/test")
-	public String Welcome() {
-		return "welcome";
-	}
-
-	@GetMapping("/texttest")
-	@ResponseBody
-	public String Blaa() {
-		System.out.println("texttest");
-		return "hello blaalaa";
-	}
-
-	// 여러 더미데이터를 넣어주는 테스트코드
-	// hibernate.hbm2ddl.auto=create 로 시작해야함.
+	@Transactional
 	@GetMapping("/inserttestdata")
-	@ResponseBody
 	public void InsertTestData() {
-
-		sessionFactory = new Configuration().configure("hibernate.cfg.xml").buildSessionFactory();
 
 		List<Shape> shapes = new ArrayList<Shape>();
 		shapes.add(new Shape("1", "네모", null));
@@ -118,26 +120,44 @@ public class TestController {
 		employee.add(Employee.builder().employeeId("95032205").authority("manager")
 				.additionalInfo(additionalInfo.get(11)).seat(null).build());
 
-		Session session = sessionFactory.openSession();
-		try {
-			Transaction tx = session.beginTransaction();
-
-			// Query
-			shapes.forEach(e -> session.save(e));
-			buildings.forEach(e -> session.save(e));
-			additionalInfo.forEach(e -> session.save(e));
-			employee.forEach(e -> session.save(e)); // instead of SQL statement
-
-			tx.commit();
-
-		} catch (Exception e) {
-			e.printStackTrace();
-
-		} finally {
-			session.close();
-			sessionFactory.close();
-			System.out.println("\n\n======= INSERT TESTDATA DONE =======\n\n\n");
-		}
-
+		shapes.forEach(e -> shapeService.save(e));
+		buildings.forEach(e -> buildingService.save(e));
+		employee.forEach(e -> employeeService.save(e));
 	}
+	
+	@Transactional
+	@RequestMapping("/get-all-buildings")
+	public ResponseEntity<List<BuildingDto>>  getAllBuildings() throws Exception {
+
+		LOGGER.info("TestController.getAllSeats called.");
+		List<Building> buildings = buildingService.findAll();
+		List<BuildingDto> result = new ArrayList<>();
+		buildings.forEach(e -> result.add(e.toDto()));
+		return new ResponseEntity<List<BuildingDto>>(result, HttpStatus.OK);
+	}
+	
+	@Transactional
+	@RequestMapping("/get-all-floors")
+	public ResponseEntity<List<FloorDto>>  getAllFloors() throws Exception {
+
+		LOGGER.info("TestController.getAllSeats called.");
+		List<Floor> floors = floorService.findAll();
+		List<FloorDto> result = new ArrayList<>();
+		floors.forEach(e -> result.add(e.toDto()));
+		return new ResponseEntity<List<FloorDto>>(result, HttpStatus.OK);
+	}
+	
+	@Transactional
+	@RequestMapping("/get-all-seats")
+	public ResponseEntity<List<SeatDto>>  getAllSeats() throws Exception {
+
+		LOGGER.info("TestController.getAllSeats called.");
+		List<Seat> seats = seatService.findAll();
+		List<SeatDto> result = new ArrayList<>();
+		seats.forEach(e -> result.add(e.toDto()));
+		return new ResponseEntity<List<SeatDto>>(result, HttpStatus.OK);
+	}
+	
+	
+	
 }

--- a/HanzariProject/backend/src/main/java/com/hancom/hanzari/repository/FloorRepository.java
+++ b/HanzariProject/backend/src/main/java/com/hancom/hanzari/repository/FloorRepository.java
@@ -2,8 +2,6 @@ package com.hancom.hanzari.repository;
 
 import java.util.List;
 
-import javax.transaction.Transactional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -17,7 +15,4 @@ public interface FloorRepository extends JpaRepository<Floor, String> {
 	Floor findByFloorNameAndBuilding(String floorName, Building building);
 
 	void deleteByFloorNameAndBuilding(String floorName, Building building);
-
-	@Transactional
-	void deleteByBuilding(Building building);
 }

--- a/HanzariProject/backend/src/main/java/com/hancom/hanzari/service/FloorService.java
+++ b/HanzariProject/backend/src/main/java/com/hancom/hanzari/service/FloorService.java
@@ -18,8 +18,6 @@ public interface FloorService {
 
 	public void deleteByFloorNameAndBuilding(String floorName, Building building);
 
-	public void deleteByBuilding(Building building);
-
 	public Floor save(Floor floor);
 	// 이건 나중에 고려해봐야할듯. 지금은 save()가 알아서 INSERT나 UPDATE로 판단해서 작동되지만 이건 Id로 체크하는게아니고
 	// floorName이랑 building정보를 동시에 조합해서 비교해봐야하기때문에 추가적으로 구현해야할 수도 있음.

--- a/HanzariProject/backend/src/main/java/com/hancom/hanzari/service/FloorService.java
+++ b/HanzariProject/backend/src/main/java/com/hancom/hanzari/service/FloorService.java
@@ -15,6 +15,8 @@ public interface FloorService {
 	public List<Floor> findByBuilding(Building building) throws Exception;
 
 	public void deleteById(String floorId); // D
+	
+	public void deleteAllInBatch(List<Floor> floors);
 
 	public void deleteByFloorNameAndBuilding(String floorName, Building building);
 

--- a/HanzariProject/backend/src/main/java/com/hancom/hanzari/service/FloorServiceImpl.java
+++ b/HanzariProject/backend/src/main/java/com/hancom/hanzari/service/FloorServiceImpl.java
@@ -54,6 +54,11 @@ public class FloorServiceImpl implements FloorService {
 	}
 
 	@Override
+	public void deleteAllInBatch(List<Floor> floors) {
+		floorRepository.deleteInBatch(floors);
+	}
+
+	@Override
 	public void deleteByFloorNameAndBuilding(String floorName, Building building) {
 		floorRepository.deleteByFloorNameAndBuilding(floorName, building);
 

--- a/HanzariProject/backend/src/main/java/com/hancom/hanzari/service/FloorServiceImpl.java
+++ b/HanzariProject/backend/src/main/java/com/hancom/hanzari/service/FloorServiceImpl.java
@@ -60,11 +60,6 @@ public class FloorServiceImpl implements FloorService {
 	}
 
 	@Override
-	public void deleteByBuilding(Building building) {
-		floorRepository.deleteByBuilding(building);
-	}
-
-	@Override
 	public Floor save(Floor floor) {
 		return floorRepository.save(floor);
 	}

--- a/HanzariProject/backend/src/main/java/com/hancom/hanzari/service/ShapeServiceImpl.java
+++ b/HanzariProject/backend/src/main/java/com/hancom/hanzari/service/ShapeServiceImpl.java
@@ -36,7 +36,6 @@ public class ShapeServiceImpl implements ShapeService {
 
 	@Override
 	public Shape save(Shape shape) {
-		// TODO 나중에 도형모양 확장 시 작성해야 할 부분
-		return null;
+		return shapeRepository.save(shape);
 	}
 }


### PR DESCRIPTION
일부 구현완료
+ test를 위한 메소드들을 TestController로 몰아 둠. 따라서 URL또한 변경 (~test-api)
   * 변경된 API 리스트
   inserttestdata -> test-api/inserttestdata
   * 추가된 리스트
   testp-api/get-all-buildings : 전체 buildings 리턴
   testp-api/get-all-floors : 전체 floors 리턴
   testp-api/get-all-seats : 전체 seats 리턴
------------------
문제점 : 하위에 seats가 존재하지 않을 경우 올바르게 동작.  하위에 seats가 존재할 경우엔 제대로 돌아가지않음.
원인 : 아마도 JPA 속성값 문제일 듯 하나 급한 메소드가 아닌 test를 위한 메소드이므로 추가 Issue를 발행하고 backlog로 보낼 계획입니다.