### PR TITLE
#624 FloorPlanController의 getImageFile 메소드의 기존 두개로 나뉘어져있던 try catch문 …

### DIFF
--- a/HanzariProject/backend/src/main/java/com/hancom/hanzari/model/Floor.java
+++ b/HanzariProject/backend/src/main/java/com/hancom/hanzari/model/Floor.java
@@ -62,7 +62,7 @@ public class Floor {
 	@JsonManagedReference
 	private List<Seat> seats;
 
-	//현재까지 구현 상황에서는 DB의 floor와 floor_plan 테이블이 연결되지 않는다.(주된 이유는 클라이언트와 통신할 때 floor와 관련된 axios호출과 floorPlan(이미지)과 관련된 axios 호출을 나눠서 해주기 때문이다.)
+	//현재까지 구현 상황에서는 DB의 floor와 floor_plan 테이블이 연결되지 않는다.(주된 이유는 클라이언트와 통신할 때 floor와 관련된 axios 호출과 floorPlan(이미지)과 관련된 axios 호출을 나눠서 해주기 때문이다.)
 	//따라서 현재까지는 두 테이블이 연결될 필요가 없어 참조되는 필드를 사용하지 않지만 후에 연결하여 호출할 경우가 있을 수도 있기에 주석처리를 해두었다.
 	//@OneToOne(cascade = CascadeType.ALL, orphanRemoval = false)
 	//@JoinColumn(name="floor_plan_id")


### PR DESCRIPTION
…하나로 통일(DB에서 이미지 서버로의 흐름은 하나의 트랜잭션으로 관리하여 중간에 하나라도 에러가 나면 이미지를 불러올 수 없도록 변경)