### PR TITLE
AssingSeats.vue 컴포넌트와 ManageSeats.vue 컴포넌트에서 함수명 변경

### DIFF
--- a/HanzariProject/frontendWireframe/src/components/AssignSeats.vue
+++ b/HanzariProject/frontendWireframe/src/components/AssignSeats.vue
@@ -147,7 +147,7 @@ export default {
       ].floorId;
     }
     //층간 이동
-    eventBus.$on("clickChangeFloorSeat", (floorId) => {
+    eventBus.$on("changeFloorSeat", (floorId) => {
       this.changeFloorSeat(floorId);
     });
 
@@ -222,7 +222,7 @@ export default {
     this.loadLatestFloor(); //현재 층 이미지와 자리 로드
   },
   beforeDestroy() {
-    eventBus.$off("clickChangeFloorSeat");
+    eventBus.$off("changeFloorSeat");
     eventBus.$off("changeFloor");
     eventBus.$off("changeFloorName");
     eventBus.$off("changeAddVacantSwitch");
@@ -1524,10 +1524,10 @@ export default {
             this.currentSelectedFloorId = floorId;
           }
         }
-        this.clickLoadOtherFloors();
+        this.loadOtherFloors();
       }
     },
-    clickLoadOtherFloors() {
+    loadOtherFloors() {
       if (this.otherFloorSeatListFromDb) {
         //다른 층 이미지 로드
         for (let i = 0; i < this.otherFloorImageFromDb.length; i++) {

--- a/HanzariProject/frontendWireframe/src/components/ManageSeats.vue
+++ b/HanzariProject/frontendWireframe/src/components/ManageSeats.vue
@@ -57,7 +57,7 @@
           ></v-select>
         </v-col>
         <v-col cols="12" sm="3">
-          <v-icon large @click="clickChangeFloorSeat">edit</v-icon></v-col
+          <v-icon large @click="changeFloorSeat">edit</v-icon></v-col
         >
       </v-row>
     </v-card>
@@ -99,8 +99,8 @@ export default {
       ];
 
       for (let i = 0; i < this.copyFromTabsFloorList.length; i++) {
-        //console.log(typeof this.currentSelectedFloor.floor_id);//String
-        //console.log(typeof this.copyFromTabsFloorList[i].floor_id); //String
+        //console.log(typeof this.currentSelectedFloor.floorId);//String
+        //console.log(typeof this.copyFromTabsFloorList[i].floorId); //String
         if (
           this.currentSelectedFloor.floorId ===
           this.copyFromTabsFloorList[i].floorId
@@ -151,9 +151,9 @@ export default {
         this.floorItems.push(this.allFloorList[i]);
       }
     },
-    clickChangeFloorSeat() {
+    changeFloorSeat() {
       if (this.selectedFloorItemsId) {
-        eventBus.$emit("clickChangeFloorSeat", this.selectedFloorItemsId);
+        eventBus.$emit("changeFloorSeat", this.selectedFloorItemsId);
       } else {
         alert("이동할 층을 선택하지 않았습니다.");
       }


### PR DESCRIPTION
함수명 ClickLoadOtherFloors 는 동작이 클릭되어야 된다는 의미인데 
현재층 로드한뒤에 다른층 로드를 하므로 loadOtherFloors 이름으로 바꾸는 것이 적절합니다.

이벤트버스명  click으로 시작하는 것은 클릭 이벤트가 있어야 하는데 해당되지 않으므로 이름을 변경했습니다.